### PR TITLE
[FEATURE] Make it possible to toggle redirectOnUpperCase on or off for each language separately

### DIFF
--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Language specific justincase configuration
+ */
+$GLOBALS['SiteConfiguration']['site_language']['columns']['redirectOnUpperCase'] = [
+    'label' => 'Redirect URL on upper-case to lower-case (Justincase)',
+    'onChange' => 'reload',
+
+    'config' => [
+        'type' => 'check',
+        'renderType' => 'checkboxToggle',
+        'default' => 1,
+        'items' => [
+            [
+                0 => '',
+                1 => ''
+            ]
+        ]
+    ]
+];
+
+$GLOBALS['SiteConfiguration']['site_language']['columns']['redirectStatusCode'] = [
+    'label' => 'Redirect status code (Justincase)',
+    'config' => [
+        'type' => 'input',
+        'default' => '307',
+        'placeholder' => '307',
+        'size' => 10
+    ],
+    'displayCond' => 'FIELD:redirectOnUpperCase:=:1'
+
+];
+
+$GLOBALS['SiteConfiguration']['site_language']['palettes']['justincase']['showitem'] = 'redirectOnUpperCase, redirectStatusCode';
+
+$GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem'] = str_replace(
+    'flag',
+    'flag, ,--palette--;;justincase',
+    $GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem']
+);

--- a/README.md
+++ b/README.md
@@ -23,8 +23,18 @@ _justincase_ requires TYPO3 v9.5.0 or later.
 As a web developer, sometimes the team wants a 307 redirect, and sometimes to just work as everything would be lower-case.
 
 _justincase_ does the latter ("just pretend it works") and receives the URL, processes the URL further by default, however
-you can configure the extension on a per-site basis to do redirects instead, by modifying the site configuration yaml
-file and adding these lines at the bottom:
+you can configure the extension on a per-site basis to do redirects instead, by modifying the Languages array of the
+site configuration yaml:
+
+    languages:
+        -
+        title: English
+        ...
+        redirectOnUpperCase: true
+        # in case you want to use a status code, other than 307
+        redirectStatusCode: 303
+
+If you wish to enable redirect for all languages, add these lines at the bottom of the site configuration yaml instead:
 
     settings:
         redirectOnUpperCase: true

--- a/src/Middleware/LowerCaseUri.php
+++ b/src/Middleware/LowerCaseUri.php
@@ -59,8 +59,19 @@ class LowerCaseUri implements MiddlewareInterface
         $doRedirect = false;
         $redirectStatusCode = 307;
         if ($site instanceof Site) {
-            $doRedirect = (bool)$site->getConfiguration()['settings']['redirectOnUpperCase'];
-            $redirectStatusCode = (int)($site->getConfiguration()['settings']['redirectStatusCode'] ?? 307);
+            $siteLanguage = $request->getAttribute('language')->toArray();
+            $doRedirect = isset($site->getConfiguration()['settings']['redirectOnUpperCase'])
+                ? (bool)$site->getConfiguration()['settings']['redirectOnUpperCase']
+                : (isset($siteLanguage['redirectOnUpperCase'])
+                    ? (bool)$siteLanguage['redirectOnUpperCase']
+                    : false
+                );
+            $redirectStatusCode = isset($site->getConfiguration()['settings']['redirectStatusCode'])
+                ? (int)$site->getConfiguration()['settings']['redirectStatusCode']
+                : (isset($siteLanguage['redirectStatusCode'])
+                    ? (int)$siteLanguage['redirectStatusCode']
+                    : 307
+                );
         }
 
         // Redirects only work on GET and HEAD requests


### PR DESCRIPTION
Some languages do not have capital letters (/zh/ko/jp/ar) to name a few) but are redirected anyway causing errors in Google Search Console.
This pull requests makes the redirectIOnUpperCase and redirectStatusCode configurable on the language level.